### PR TITLE
Add handling of new GCP families c4d, m4 and a4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Cache Go module dependencies
         id: cache-go-module-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cache licenses
         id: cache-licenses
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .licensei.cache
           key: licensei-v1-${{ steps.set-git-refname.outputs.git_refname }}-${{ hashFiles('go.sum') }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Cache Go module dependencies
         id: cache-go-module-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Restore Go module dependencies cache
         id: cache-go-module-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
@@ -143,7 +143,7 @@ jobs:
 
       - name: Restore Go module dependencies cache
         id: cache-go-module-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/go/pkg/mod
           key: go-mod-cache-${{ runner.os }}-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}

--- a/internal/cloudinfo/providers/google/cloudinfo.go
+++ b/internal/cloudinfo/providers/google/cloudinfo.go
@@ -38,15 +38,15 @@ import (
 const svcGke = "gke"
 
 var regionNames = map[string]string{
-	"asia-east1":              "Asia Pacific (Taiwan)",
-	"asia-east2":              "Asia Pacific (Hong Kong)",
-	"asia-northeast1":         "Asia Pacific (Tokyo)",
-	"asia-northeast2":         "Asia Pacific (Osaka)",
-	"asia-northeast3":         "Asia Pacific (Seoul)",
-	"asia-south1":             "Asia Pacific (Mumbai)",
-	"asia-south2":             "Asia Pacific (Delhi)",
-	"asia-southeast1":         "Asia Pacific (Singapore)",
-	"asia-southeast2":         "Asia Pacific (Jakarta)",
+	"asia-east1":      "Asia Pacific (Taiwan)",
+	"asia-east2":      "Asia Pacific (Hong Kong)",
+	"asia-northeast1": "Asia Pacific (Tokyo)",
+	"asia-northeast2": "Asia Pacific (Osaka)",
+	"asia-northeast3": "Asia Pacific (Seoul)",
+	"asia-south1":     "Asia Pacific (Mumbai)",
+	"asia-south2":     "Asia Pacific (Delhi)",
+	"asia-southeast1": "Asia Pacific (Singapore)",
+	"asia-southeast2": "Asia Pacific (Jakarta)",
 
 	"australia-southeast1":    "Asia Pacific (Sydney)",
 	"australia-southeast2":    "Asia Pacific (Melbourne)",
@@ -257,7 +257,8 @@ func (g *GceInfoer) Initialize() (map[string]map[string]types.Price, error) {
 func isSupportedFamily(family string) bool {
 	return family == "a2" || family == "a3" || family == "c3" || family == "c3d" || family == "c4" ||
 		family == "e2" || family == "g2" || family == "h3" || family == "n2" || family == "n4" || family == "m3" ||
-		family == "c4a" || family == "t2a" || family == "n2d" || family == "c2d" || family == "t2d" || family == "z3"
+		family == "c4a" || family == "t2a" || family == "n2d" || family == "c2d" || family == "t2d" || family == "z3" ||
+		family == "c4d" || family == "m4"
 }
 
 func (g *GceInfoer) getPrice() (map[string]map[string]map[string]float64, error) {
@@ -331,7 +332,7 @@ func (g *GceInfoer) getPrice() (map[string]map[string]map[string]float64, error)
 				}
 				resMatch := (descSplit[1] == "Instance" && (descSplit[2] == "Ram" || descSplit[2] == "Core")) ||
 					(descSplit[2] == "Instance" && (descSplit[3] == "Ram" || descSplit[3] == "Core") &&
-					(descSplit[1] == "Memory-optimized" || descSplit[1] == "Arm" || descSplit[1] == "AMD"))
+						(descSplit[1] == "Memory-optimized" || descSplit[1] == "Arm" || descSplit[1] == "AMD"))
 				if !resMatch {
 					continue
 				}

--- a/internal/cloudinfo/providers/google/cloudinfo.go
+++ b/internal/cloudinfo/providers/google/cloudinfo.go
@@ -258,7 +258,7 @@ func isSupportedFamily(family string) bool {
 	return family == "a2" || family == "a3" || family == "c3" || family == "c3d" || family == "c4" ||
 		family == "e2" || family == "g2" || family == "h3" || family == "n2" || family == "n4" || family == "m3" ||
 		family == "c4a" || family == "t2a" || family == "n2d" || family == "c2d" || family == "t2d" || family == "z3" ||
-		family == "c4d" || family == "m4"
+		family == "c4d" || family == "m4" || family == "a4"
 }
 
 func (g *GceInfoer) getPrice() (map[string]map[string]map[string]float64, error) {


### PR DESCRIPTION
This PR adds handling of new GCP instance type families c4d, m4 and a4. Without this addition, new families were reporting on demand price of 0.

### How was this tested?

Cloud info was run for Google cloud provider. Generated Json files were sampled for newer instance families such as "c4d-highmem-16". Further ensured that no zero ondemand prices existed: `\"onDemandPrice\": 0` 