### PR TITLE
Skipping instance types with unavailable on-demand prices

### DIFF
--- a/internal/cloudinfo/providers/google/cloudinfo.go
+++ b/internal/cloudinfo/providers/google/cloudinfo.go
@@ -222,6 +222,10 @@ func (g *GceInfoer) Initialize() (map[string]map[string]types.Price, error) {
 							prices.OnDemandPrice = price["m3-cpu"]["OnDemand"]*float64(mt.GuestCpus) + price["m3-memory"]["OnDemand"]*float64(mt.MemoryMb)/1024
 						case isSupportedFamily(family):
 							prices.OnDemandPrice = price[family+"-cpu"]["OnDemand"]*float64(mt.GuestCpus) + price[family+"-memory"]["OnDemand"]*float64(mt.MemoryMb)/1024
+							if prices.OnDemandPrice == 0 {
+								g.log.Error("On Demand price of 0 detected indicating that price wasn't available, Skipping type (mt.name): " + mt.Name)
+								continue
+							}
 						default:
 							g.log.Warn("could not get price", map[string]interface{}{"machineTypeName": mt.Name})
 						}


### PR DESCRIPTION
These were the instance types were skipped when the tool was run:
      a4-highgpu
      c4-highcpu, c4-highmem, c4-standard
      n4-highcpu, n4-highmem, n4-standard
      